### PR TITLE
Add json dump to SN page

### DIFF
--- a/observer.py
+++ b/observer.py
@@ -415,8 +415,6 @@ def block_with_txs_req(lmq, oxend, hash_or_height, **kwargs):
     return FutureJSON(lmq, oxend, 'rpc.get_block', cache_key='single', args=args, **kwargs)
 
 
-@app.route('/service_node/<hex64:pubkey>')                      # For backwards compatibility 
-@app.route('/service_node/<hex64:pubkey>/<int:more_details>')   # with old explorer URLs
 @app.route('/sn/<hex64:pubkey>')
 @app.route('/sn/<hex64:pubkey>/<int:more_details>')
 def show_sn(pubkey, more_details=False):

--- a/templates/sn.html
+++ b/templates/sn.html
@@ -231,5 +231,18 @@
         {%endfor%}
       </table>
     {%endif%}
+
+    {%if details_html%}
+      <style type="text/css">
+        {{details_css | safe}}
+      </style>
+      <div class="TitleDivider" id="more_details"></div>
+        {{details_html | safe}}
+      {%else%}
+      <h5>
+        <a href="/sn/{{sn.service_node_pubkey}}/1#more_details">Show raw details</a>
+      </h5>
+    {%endif%}
 </div>
-{%endblock%}
+{% endblock %}
+


### PR DESCRIPTION
Allow user to view a raw json dump of a Service Node by clicking a "Show raw details" link