### PR TITLE
Sort active nodes by last uptime proof.

### DIFF
--- a/templates/include/sn_active.html
+++ b/templates/include/sn_active.html
@@ -5,19 +5,19 @@
             <td>Contri&shy;butors</td>
             <td>Operator Fee (%)</td>
             <td>Staking Requirement</td>
-            <td title="Can also be the height of the last activation, IP penalty, or recommission">Last Reward Height</td>
+            <td title="Can also be the height of the last IP penalty or recommission">Active Since Height</td>
             <td>Last Uptime Proof</td>
             <td>Expiry Date UTC (Estimated)</td>
         </tr>
     </thead>
 
     <tbody>
-        {%for sn in (active_sns | sort(attribute='last_reward_block_height,last_reward_transaction_index,service_node_pubkey'))[:limit_active]%}
+        {%for sn in (active_sns | sort(attribute='last_uptime_proof,service_node_pubkey'))[:limit_active]%}
 
             <tr>
                 {%include 'include/sn_kcf.html'%}
                 <td>{{sn.staking_requirement | oxen(tag=false, fixed=true)}}</td>
-                <td>{{sn.last_reward_block_height}}</td>
+                <td>{{sn.state_height}}</td>
                 <td>{{sn.last_uptime_proof | from_timestamp | ago if sn.last_uptime_proof > 0 else "Not Received"}}</td>
                 <td>
                     {%if sn.requested_unlock_height%}


### PR DESCRIPTION
Since HF19, there is no longer a concept of a per node reward height, so
we need a new sort criterion for active nodes. I believe the most
interesting sort is that by most recent uptime proof.

At the top of the list will appear nodes whose proof is overdue
(i.e. > 1:00:00 ago). This should never be more than a few seconds, so
one can see at a glance any nodes that are ripe for being moved to the
Inactive/Decommissioned Service Nodes section the next time they are
tested by the network. This also makes the list much more dynamic to
watch.

Since the Last Reward Height column is now redundant, we can replace it
with something more interesting, such as the Active Since Height.

<img width="1527" alt="image" src="https://user-images.githubusercontent.com/749942/176640618-6cc11eef-47af-4026-af3b-fb2eb65a9308.png">
