### PR TITLE
Oxen 11 dev compat

### DIFF
--- a/templates/block.html
+++ b/templates/block.html
@@ -50,7 +50,7 @@ Validator bits: {{"{:011b}".format(block.info.pulse.validator_bitset)}}"><label>
         {%endif%}
 
         {%set sum_burned = transactions | selectattr('extra.burn_amount') | sum(attribute='extra.burn_amount') %}
-        {%set sum_fees = transactions | selectattr('info.rct_signatures') | selectattr('info.rct_signatures.txnFee') | sum(attribute='info.rct_signatures.txnFee') - sum_burned%}
+        {%set sum_fees = transactions | selectattr('rct_signatures') | selectattr('rct_signatures.txnFee') | sum(attribute='rct_signatures.txnFee') - sum_burned%}
 
         <span title="{{(block_header.reward - sum_fees) | oxen(fixed=True)}} created in this block.{%if sum_fees > 0%}
 
@@ -91,9 +91,9 @@ Note that this value does not include earned transaction fees ({{sum_fees | oxen
         </tr>
         <tr>
             <td><a href="/tx/{{miner_tx.tx_hash}}">{{miner_tx.tx_hash}}</a></td>
-            <td>{{miner_tx.info.vout | sum(attribute='amount') | oxen}}</td>
+            <td>{{miner_tx.vout | sum(attribute='amount') | oxen}}</td>
             <td>{{miner_tx.size}}</td>
-            <td>{{miner_tx.info.version}}</td>
+            <td>{{miner_tx.version}}</td>
         </tr>
     </table>
     {%endif%}
@@ -122,7 +122,7 @@ Note that this value does not include earned transaction fees ({{sum_fees | oxen
                   <td><a href="/tx/{{tx.tx_hash}}">{{tx.tx_hash}}</a></td>
                   <td>{{fee.display(tx)}}</td>
                   <td></td>
-                  <td>{{tx.info.vin | length}}/{{tx.info.vout | length}}</td>
+                  <td>{{tx.vin | length}}/{{tx.vout | length}}</td>
                   <td>{{tx.size | si}}B</td>
                 </tr>
             {% endfor %}

--- a/templates/include/mempool.html
+++ b/templates/include/mempool.html
@@ -29,13 +29,13 @@
                 <td>{{symbol.display(tx)}}</td>
                 <td><a href="/tx/{{tx.id_hash}}">{{tx.id_hash}}</a></td>
                 <td>
-                    {%if 'rct_signatures' in tx.info%}
-                        {{fee.display(tx)}} / {{(tx.info.rct_signatures.txnFee * 1000 / tx.blob_size) | oxen(tag=false, decimals=4)}}
+                    {%if 'rct_signatures' in tx%}
+                        {{fee.display(tx)}} / {{(tx.rct_signatures.txnFee * 1000 / tx.blob_size) | oxen(tag=false, decimals=4)}}
                     {%else%}
                         N/A
                     {%endif%}
                 </td>
-                <td>{{tx.info.vin | length}}/{{tx.info.vout | length}}</td>
+                <td>{{tx.vin | length}}/{{tx.vout | length}}</td>
                 <td>{{tx.blob_size | si}}B</td>
             </tr>
         {% endfor %}

--- a/templates/include/mempool.html
+++ b/templates/include/mempool.html
@@ -1,12 +1,12 @@
 {# Lists mempool transactions.  mempool_limit can be set to limit the number of shown transactions; defaults to 25.  Set explicitly to none to show all. #}
 {% if not mempool_limit is defined %}{% set mempool_limit = 25 %}
-{% elif mempool_limit is none %}{% set mempool_limit = mempool.transactions|length %}
+{% elif mempool_limit is none %}{% set mempool_limit = mempool.txs|length %}
 {% endif %}
 <div class="Wrapper">
     <h2 style="margin-bottom: 0px"> Transaction Pool</h2>
 
-    <h4 class="Subtitle">{{mempool.transactions|length}} transactions,
-        {{mempool.transactions|sum(attribute='blob_size') | si}}B</h4>
+    <h4 class="Subtitle">{{mempool.txs|length}} transactions,
+        {{mempool.txs|sum(attribute='size') | si}}B</h4>
     <div class="TitleUnderliner"></div>
 
     <table style="width:100%">
@@ -23,28 +23,28 @@
         <tbody>
         {% import 'include/tx_type_symbol.html' as symbol %}
         {% import 'include/tx_fee.html' as fee %}
-        {% for tx in mempool.transactions[:mempool_limit] %}
+        {% for tx in mempool.txs[:mempool_limit] %}
             <tr>
-                <td title="{{tx.receive_time | from_timestamp | format_datetime}}">{{tx.receive_time | from_timestamp | ago}}</td>
+                <td title="{{tx.received_timestamp | from_timestamp | format_datetime}}">{{tx.received_timestamp | from_timestamp | ago}}</td>
                 <td>{{symbol.display(tx)}}</td>
-                <td><a href="/tx/{{tx.id_hash}}">{{tx.id_hash}}</a></td>
+                <td><a href="/tx/{{tx.tx_hash}}">{{tx.tx_hash}}</a></td>
                 <td>
                     {%if 'rct_signatures' in tx%}
-                        {{fee.display(tx)}} / {{(tx.rct_signatures.txnFee * 1000 / tx.blob_size) | oxen(tag=false, decimals=4)}}
+                        {{fee.display(tx)}} / {{(tx.rct_signatures.txnFee * 1000 / tx.size) | oxen(tag=false, decimals=4)}}
                     {%else%}
                         N/A
                     {%endif%}
                 </td>
                 <td>{{tx.vin | length}}/{{tx.vout | length}}</td>
-                <td>{{tx.blob_size | si}}B</td>
+                <td>{{tx.size | si}}B</td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
 
-    {% if mempool.transactions|length > mempool_limit %}
+    {% if mempool.txs|length > mempool_limit %}
         <div class="center" style="text-align: center; margin-bottom: 10px">
-            <a href="/txpool">Only {{mempool_limit}}/{{mempool.transactions | length}} transactions shown. Click here to see all of them</a>
+            <a href="/txpool">Only {{mempool_limit}}/{{mempool.txs | length}} transactions shown. Click here to see all of them</a>
         </div>
     {% endif %}
 

--- a/templates/include/sn_awaiting.html
+++ b/templates/include/sn_awaiting.html
@@ -18,7 +18,8 @@
             <tr>
                 {%include 'include/sn_kcf.html'%}
                 <td>{{sn.total_contributed | oxen(tag=false, fixed=true)}}</td>
-                {%if sn.total_reserved >= sn.staking_requirement%}
+                {% set total_stakes = sn.total_reserved if 'total_reserved' in sn else sn.total_contributed %}
+                {%if total_stakes >= sn.staking_requirement%}
                     <td title="All remaining contribution room is reserved for specific contributors">
                         ⛔ {{sn.contribution_open | oxen(tag=false, fixed=true)}}
                     </td>

--- a/templates/include/tx_fee.html
+++ b/templates/include/tx_fee.html
@@ -1,6 +1,6 @@
 {% macro display(tx, show_zero=false) -%}
     {% set fee =
-        (tx.info.rct_signatures.txnFee if 'rct_signatures' in tx.info and 'txnFee' in tx.info.rct_signatures else 0)
+        (tx.rct_signatures.txnFee if 'rct_signatures' in tx and 'txnFee' in tx.rct_signatures else 0)
     -%}
     {% if fee > 0 or show_zero -%}
         {{ fee | oxen(tag=False, fixed=True, decimals=4) }}

--- a/templates/include/tx_type_symbol.html
+++ b/templates/include/tx_type_symbol.html
@@ -1,6 +1,6 @@
 {%- macro display(tx, text=false) -%}
-    {% if tx.info.version >= 4 -%}
-        {% if tx.info.type == 1 and 'sn_state_change' in tx.extra -%}
+    {% if tx.version >= 4 -%}
+        {% if tx.type == 1 and 'sn_state_change' in tx.extra -%}
             {% if tx.extra.sn_state_change.type == 'decom' -%}
                 <span class="icon" title="Service Node decommission">👎{%if text%} decommission{%endif%}</span>
             {% elif tx.extra.sn_state_change.type == 'recom' -%}
@@ -12,9 +12,9 @@
             {% else -%}
                 <span class="icon" title="Unknown state change transaction">❓{%if text%} unknown state change{%endif%}</span><!-- Either a bug or a malformed transaction -->
             {% endif -%}
-        {% elif tx.info.type == 2 -%}
+        {% elif tx.type == 2 -%}
             <span class="icon" title="Service Node stake unlock — {{tx.extra.sn_pubkey}}">🔓{%if text%} unlock{%endif%}</span>
-        {% elif tx.info.type == 4 and 'ons' in tx.extra -%}
+        {% elif tx.type == 4 and 'ons' in tx.extra -%}
             {% if 'buy' in tx.extra.ons -%}
                 <span class="icon" title="Oxen Name Service Buying">🎫{%if text%} LNS purchase{%endif%}</span>
             {% elif 'update' in tx.extra.ons -%}

--- a/templates/index.html
+++ b/templates/index.html
@@ -177,7 +177,7 @@
                   <td><a href="/tx/{{b.txs[0].tx_hash}}">{{b.txs[0].tx_hash}}</a></td>
                   <td>{{fee.display(b.txs[0])}}</td>
                   <td>{{b.coinbase_payouts | oxen(tag=False, fixed=True, decimals=2)}}</td>
-                  <td>0/{{b.txs[0].info.vout | length}}</td>
+                  <td>0/{{b.txs[0].vout | length}}</td>
                   <td>{{b.txs[0].size | si}}</td>
                 </tr>
               {% else %}
@@ -203,7 +203,7 @@
                   <td><a href="/tx/{{tx.tx_hash}}">{{tx.tx_hash}}</a></td>
                   <td>{{fee.display(tx)}}</td>
                   <td></td>
-                  <td>{{tx.info.vin | length}}/{{tx.info.vout | length}}</td>
+                  <td>{{tx.vin | length}}/{{tx.vout | length}}</td>
                   <td>{{tx.size | si}}</td>
                 </tr>
               {% endfor %}

--- a/templates/sn.html
+++ b/templates/sn.html
@@ -60,7 +60,7 @@
     </span>
 
     {%if 'total_reserved' in sn and sn.total_reserved != sn.total_contributed%}
-      <span><label>Reserved stakes:</label> {{sn.total_reserved - sn.total_contributed | oxen}}</span>
+      <span><label>Reserved stakes:</label> {{(sn.total_reserved - sn.total_contributed) | oxen}}</span>
     {%endif%}
 
     <span>

--- a/templates/sn.html
+++ b/templates/sn.html
@@ -59,8 +59,8 @@
       {%endif%}
     </span>
 
-    {%if sn.total_reserved != sn.total_contributed%}
-      <span><label>Total reserved:</label> {{sn.total_reserved | oxen}}</span>
+    {%if 'total_reserved' in sn and sn.total_reserved != sn.total_contributed%}
+      <span><label>Reserved stakes:</label> {{sn.total_reserved - sn.total_contributed | oxen}}</span>
     {%endif%}
 
     <span>
@@ -94,35 +94,10 @@
     </span>
 
     {%if info.service_node%}{# SN tests are only conducted by SNs #}
-      <span>
-        <label{%if sn.storage_server_last_unreachable > sn.storage_server_last_reachable%} class="omg warning"{%endif%}>Storage server:</label>
-        {%if sn.storage_server_last_reachable == 0 and sn.storage_server_last_unreachable == 0%}
-          Not yet tested
-        {%elif sn.storage_server_last_reachable >= sn.storage_server_last_unreachable%}
-          <span title="Last unreachable: {%if sn.storage_server_last_unreachable == 0%}Unknown{%else%}{{sn.storage_server_last_unreachable | from_timestamp | ago}} ago{%endif%}">
-            Reachable (as of {{sn.storage_server_last_reachable | from_timestamp | ago}} ago
-          </span>
-        {%else%}
-          <span title="Last reachable: {%if sn.storage_server_last_reachable == 0%}Unknown{%else%}{{sn.storage_server_last_reachable | from_timestamp | ago}} ago{%endif%}">
-          Not reachable (as of {{sn.storage_server_last_unreachable | from_timestamp | ago}} ago)
-          </span>
-        {%endif%}
-      </span>
+      {% import 'include/reachable.html' as reachable %}
 
-      <span>
-        <label{%if sn.lokinet_last_unreachable > sn.lokinet_last_reachable%} class="omg warning"{%endif%}>Lokinet:</label>
-        {%if sn.lokinet_last_reachable == 0 and sn.lokinet_last_unreachable == 0%}
-          Not yet tested
-        {%elif sn.lokinet_last_reachable >= sn.lokinet_last_unreachable%}
-          <span title="Last unreachable: {%if sn.lokinet_last_unreachable == 0%}Unknown{%else%}{{sn.lokinet_last_unreachable | from_timestamp | ago}} ago{%endif%}">
-            Reachable (as of {{sn.lokinet_last_reachable | from_timestamp | ago}} ago
-          </span>
-        {%else%}
-          <span title="Last reachable: {%if sn.lokinet_last_reachable == 0%}Unknown{%else%}{{sn.lokinet_last_reachable | from_timestamp | ago}} ago{%endif%}">
-          Not reachable (as of {{sn.lokinet_last_unreachable | from_timestamp | ago}} ago)
-          </span>
-        {%endif%}
-      </span>
+      {{reachable.display(sn)}}
+      {{reachable.display(sn, true)}}
     {%endif%}
 
     {%set pulse_voted = sn.pulse_participation | selectattr("voted") | list | length%}
@@ -188,7 +163,8 @@
     <p class="sn-awaiting">Awaiting registration.  This service node has <span class="oxen required">{{(sn.staking_requirement - sn.total_contributed) | oxen}}</span>
     remaining to be contributed.
     {%if sn.num_open_spots > 0%}
-      The minimum required stake contribution is <span class="oxen required">{{((sn.staking_requirement - sn.total_reserved) / sn.num_open_spots) | oxen}}</span>.
+      {%set total_staked = sn.total_reserved if 'total_reserved' in sn else sn.total_contributed%}
+      The minimum required stake contribution is <span class="oxen required">{{((sn.staking_requirement - total_staked) / sn.num_open_spots) | oxen}}</span>.
     {%endif%}
     </p>
   {%endif%}
@@ -224,7 +200,7 @@
                 ({{c.locked_contributions|length}} contributions)
               {%endif-%}
             </td>
-            <td>{{c.reserved | oxen}}</td>
+            <td>{{(c.reserved if 'reserved' in c else c.amount) | oxen}}</td>
           </tr>
         {%endfor%}
       </tbody>

--- a/templates/tx.html
+++ b/templates/tx.html
@@ -219,7 +219,7 @@ This tx does not includes a vote from this testing service node (only 7 votes ar
     {%if tx.vout%}
         <h2>Outputs</h2>
         <h4 class="Subtitle">{{tx.vout|length}} output(s) for total of
-            {{tx.vout | sum(attribute='amount') | oxen(zero='<span title="Regular LOKI tx amounts are private">???</span>') | safe}}</h4>
+            {{tx.vout | sum(attribute='amount') | oxen(zero='<span title="Regular OXEN tx amounts are private">???</span>') | safe}}</h4>
         <div class="TitleDivider"></div>
         <div class="tx-outputs">
             <table class="Table">
@@ -554,7 +554,7 @@ This tx does not includes a vote from this testing service node (only 7 votes ar
 
       <h2>Inputs</h2>
       <h4 class="Subtitle">{{tx.vin|length}} input(s) for total of
-        {{tx.vin | sum(attribute='key.amount') | oxen(zero='<span title="Regular LOKI tx amounts are private">???</span>') | safe}}</h4>
+        {{tx.vin | sum(attribute='key.amount') | oxen(zero='<span title="Regular OXEN tx amounts are private">???</span>') | safe}}</h4>
       <div class="TitleDivider"></div>
 
       {#FIXME#}

--- a/templates/tx.html
+++ b/templates/tx.html
@@ -46,7 +46,7 @@
           <span title="Unix timestamp: {{tx.received_timestamp}}"><label>In mempool since:</label> {{tx.received_timestamp | from_timestamp | format_datetime('short')}} UTC
           ({{tx.received_timestamp | from_timestamp | ago}} ago)</span>
         {%endif%}
-        <span><label>TX Version/Type:</label> {{tx.info.version}}/{{sym.display(tx, text=true)}}</span>
+        <span><label>TX Version/Type:</label> {{tx.version}}/{{sym.display(tx, text=true)}}</span>
         {%if not have_raw_tx%}
           {%if 'block_timestamp' in tx%}
             <span title="Unix timestamp: {{tx.block_timestamp}}"><label>Timestamp:</label> {{tx.block_timestamp | from_timestamp | format_datetime('short')}} UTC
@@ -56,17 +56,17 @@
 
         {# FIXME - if in mempool then link to mempool page instead #}
         <span><label>Fee (Per kB):</label>
-            {%if tx.coinbase or 'rct_signatures' not in tx.info%}
+            {%if tx.coinbase or 'rct_signatures' not in tx%}
                 N/A
             {%else%}
                 {{fee.display(tx)}}
-                ({{(tx.info.rct_signatures.txnFee * 1000 / tx.size) | oxen(tag=false, decimals=6)}})
+                ({{(tx.rct_signatures.txnFee * 1000 / tx.size) | oxen(tag=false, decimals=6)}})
             {%endif%}
         </span>
         <span title="{{tx.size}} bytes"><label>TX Size:</label> {{tx.size|si}}B</span>
 
         <span><label>No. Confirmations:</label> {%if 'block_height' in tx%}{{info.height - tx.block_height}}{%else%}None (in mempool){%endif%}</span>
-        <span><label>RingCT/RingCT Type:</label> {%if tx.info.version >= 2 and 'rct_signatures' in tx.info and not tx.coinbase%}Yes/{{tx.info.rct_signatures.type}}{%else%}No{%endif%}</span>
+        <span><label>RingCT/RingCT Type:</label> {%if tx.version >= 2 and 'rct_signatures' in tx and not tx.coinbase%}Yes/{{tx.rct_signatures.type}}{%else%}No{%endif%}</span>
 
         {%if tx.coinbase and tx.extra.sn_winner%}
           <span><label>Service Node Winner:</label>
@@ -78,10 +78,10 @@
           </span>
         {%endif%}
     </h4>
-    <div class="info-item"><label>Extra: </label>{{tx.info.extra}}</div>
+    <div class="info-item"><label>Extra: </label>{{tx.tx_extra_raw}}</div>
 
-    {% if tx.info.version >= 4 -%}
-        {% if tx.info.type == 1 and 'sn_state_change' in tx.extra %}
+    {% if tx.version >= 4 -%}
+        {% if tx.type == 1 and 'sn_state_change' in tx.extra %}
             <h2>
             {%- set show_reasons = false -%}
             {% if tx.extra.sn_state_change.type == 'decom' -%}
@@ -159,12 +159,12 @@ This tx does not includes a vote from this testing service node (only 7 votes ar
                 </div>
             {%endif%}
 
-        {% elif tx.info.type == 2 %}
+        {% elif tx.type == 2 %}
             <h2>🔓 Service Node Unlock</h2>
             <p class="unlock-pubkey"><label>Service Node Public Key:</label> <a href="/sn/{{tx.extra.sn_pubkey}}">{{tx.extra.sn_pubkey}}</a></p>
             <p><label>Unlock key image:</label> {{unlock_key_image}}</p> {# FIXME #}
             <p><label>Unlock signature:</label> {{unlock_signature}}</p> {# FIXME #}
-        {% elif tx.info.type == 4 and 'lns' in tx.extra %}
+        {% elif tx.type == 4 and 'lns' in tx.extra %}
             {% if 'buy' in tx.extra.lns %}
                 <h2>🎫 Oxen Name Service Registration</h2>
             {% elif 'update' in tx.extra.lns %}
@@ -216,10 +216,10 @@ This tx does not includes a vote from this testing service node (only 7 votes ar
     {% endif %}
 
 
-    {%if tx.info.vout%}
+    {%if tx.vout%}
         <h2>Outputs</h2>
-        <h4 class="Subtitle">{{tx.info.vout|length}} output(s) for total of
-            {{tx.info.vout | sum(attribute='amount') | oxen(zero='<span title="Regular LOKI tx amounts are private">???</span>') | safe}}</h4>
+        <h4 class="Subtitle">{{tx.vout|length}} output(s) for total of
+            {{tx.vout | sum(attribute='amount') | oxen(zero='<span title="Regular LOKI tx amounts are private">???</span>') | safe}}</h4>
         <div class="TitleDivider"></div>
         <div class="tx-outputs">
             <table class="Table">
@@ -232,7 +232,7 @@ This tx does not includes a vote from this testing service node (only 7 votes ar
                 </thead>
 
                 <tbody>
-                    {%for out in tx.info.vout%}
+                    {%for out in tx.vout%}
                         <tr>
                             <td><label>{{loop.index0}}:</label> {{out.target.key}}</td>
                             <td>{{out.amount | oxen(zero='?')}}</td>
@@ -549,12 +549,12 @@ This tx does not includes a vote from this testing service node (only 7 votes ar
     {%endif%}
     #}
 
-    {%if not tx.coinbase and tx.info.vin|length > 0 %}
+    {%if not tx.coinbase and tx.vin|length > 0 %}
       <div style="height: 1em"></div>
 
       <h2>Inputs</h2>
-      <h4 class="Subtitle">{{tx.info.vin|length}} input(s) for total of
-        {{tx.info.vin | sum(attribute='key.amount') | oxen(zero='<span title="Regular LOKI tx amounts are private">???</span>') | safe}}</h4>
+      <h4 class="Subtitle">{{tx.vin|length}} input(s) for total of
+        {{tx.vin | sum(attribute='key.amount') | oxen(zero='<span title="Regular LOKI tx amounts are private">???</span>') | safe}}</h4>
       <div class="TitleDivider"></div>
 
       {#FIXME#}
@@ -574,7 +574,7 @@ This tx does not includes a vote from this testing service node (only 7 votes ar
 
       <div class="tx-inputs">
         <table class="Table">
-          {%for inp in tx.info.vin if 'key' in inp%}
+          {%for inp in tx.vin if 'key' in inp%}
             <tr class="tx-input-key-image">
               <td style="text-align: left;" colspan="2">
                 <label>Key Image {{loop.index0}}:</label> {{inp.key.k_image}}


### PR DESCRIPTION
Updates for dev branch oxen-core compatibility.

The dev branch has a rewritten RPC layer, which made some some logical changes to the output of some endpoints (and some fixes in https://github.com/oxen-io/oxen-core/pull/1620 applied).  This updates oxen observer to be compatible with the (soon-to-be) dev branch (but also keeps current Oxen 10.x compatibility).

The main changes here that affect the observer are:
- tx details are now returned directly in the transaction details; previously they were stucked into a double-json-encoded "as_json" key which was just gross.
- most of the reachable/unreachable keys are now omitted when the node doesn't have any data for that element (e.g. if it has never been unreachable then `storage_server_last_unreachable` is now omitted, but used to be 0).
- accrued batch earnings is now an object (dict) of wallet => amount rather than a pair of parallel wallet/amount arrays.